### PR TITLE
Use sequence number for MultiplexedContext

### DIFF
--- a/spekka-context/src/main/scala/spekka/context/internal/Contexts.scala
+++ b/spekka-context/src/main/scala/spekka/context/internal/Contexts.scala
@@ -18,14 +18,15 @@ package spekka.context.internal
 
 import spekka.context.StackableContext
 
-/** Defines that a particular context having a hash equal to `hash` is multiplexed for `n` elements
+/** Defines that a particular context having a particular sequence number is multiplexed for `n`
+  * elements
   *
-  * @param hash
-  *   The hash of the original context
+  * @param seqNr
+  *   The sequence number associated to the context
   * @param n
   *   The number of elements the context is multiplexed for
   */
-private[spekka] case class MultiplexedContext(hash: Int, n: Int) extends StackableContext
+private[spekka] case class MultiplexedContext(seqNr: Long, n: Int) extends StackableContext
 
 /** Defines the sequence number associated to a particular context
   *

--- a/spekka-context/src/main/scala/spekka/context/internal/Ordered.scala
+++ b/spekka-context/src/main/scala/spekka/context/internal/Ordered.scala
@@ -154,7 +154,7 @@ private[spekka] object Ordered {
               if (seqCtx.seqNr < nextSeqNr && seqCtx.seqNr < nextSeqNr + bufferSize) {
                 failStage(
                   new IllegalStateException(
-                    s"Received old sequence number. Expected minimum [$nextSeqNr]"
+                    s"Received unexpected sequence number ${seqCtx.seqNr}. Expected range [$nextSeqNr, ${nextSeqNr + bufferSize}]"
                   )
                 )
               } else if (seqCtx.seqNr == nextSeqNr) {

--- a/spekka-context/src/main/scala/spekka/context/internal/PartitionDynamicInternal.scala
+++ b/spekka-context/src/main/scala/spekka/context/internal/PartitionDynamicInternal.scala
@@ -396,7 +396,7 @@ private[spekka] object PartitionDynamicInternal {
           val keys = multiPartitioner.keyF(data, ctx.innerContext, liveKeys)
           val newCtx = ctx.push(
             MultiplexedContext(
-              globalSeqNr.hashCode(),
+              globalSeqNr,
               Math.max(keys.size, 1)
             )
           )

--- a/spekka-context/src/test/scala/spekka/context/OrderedSuite.scala
+++ b/spekka-context/src/test/scala/spekka/context/OrderedSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Andrea Zito
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spekka.context
+
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import spekka.test.SpekkaSuite
+
+import scala.util.Failure
+import scala.util.Success
+
+class OrderedSuite extends SpekkaSuite("OrderedSuite") {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import FlowWithExtendedContext._
+
+  def testOrder(batchSize: Int)(flow: FlowWithExtendedContext[Int, _, Long, _]) = {
+    val source = Source.fromIterator(() => Iterator.from(0).take(200000)).zipWithIndex
+
+    val checkSink = Sink.fold[Long, Long](0L) { case (expected, res) =>
+      res shouldBe expected
+      expected + 1
+    }
+
+    val done = source.via(flow.ordered(batchSize)).map(_._2).runWith(checkSink).andThen {
+      case Success(_) =>
+      case Failure(exception) => exception.printStackTrace()
+    }
+
+    done.futureValue
+  }
+
+  def reorderFlow[T](batchSize: Int) =
+    Flow[T].statefulMapConcat(() => {
+      val buff = scala.collection.mutable.ListBuffer[T]()
+
+      in =>
+        buff += in
+        if (buff.size >= batchSize) {
+          val res = buff.toList
+          buff.clear()
+          res.reverse
+        } else Nil
+    })
+
+  test("ordered has no effect on already ordered sync flow") {
+    testOrder(1)(FlowWithExtendedContext[Int, Long].map(_.toHexString))
+  }
+
+  test("ordered has no effect on already ordered async flow") {
+    testOrder(1)(FlowWithExtendedContext[Int, Long].map(_.toHexString).async)
+  }
+
+  test("ordered enforce ordering on unordered sync flow with small batch size") {
+    val batchSize = 10
+    testOrder(batchSize) {
+      FlowWithExtendedContext[Int, Long].toFlow
+        .via(reorderFlow(batchSize))
+        .asFlowWithExtendedContextUnsafe
+    }
+  }
+
+  test("ordered enforce ordering on unordered sync flow with large batch size") {
+    val batchSize = 500
+    testOrder(batchSize) {
+      FlowWithExtendedContext[Int, Long].toFlow
+        .via(reorderFlow(batchSize))
+        .asFlowWithExtendedContextUnsafe
+    }
+  }
+
+  test("ordered enforce ordering on unordered async flow with small batch size") {
+    val batchSize = 10
+    testOrder(batchSize) {
+      FlowWithExtendedContext[Int, Long].toFlow
+        .via(reorderFlow(batchSize))
+        .asFlowWithExtendedContextUnsafe
+        .async
+    }
+  }
+
+  test("ordered enforce ordering on unordered async flow with large batch size") {
+    val batchSize = 500
+    testOrder(batchSize) {
+      FlowWithExtendedContext[Int, Long].toFlow
+        .via(reorderFlow(batchSize))
+        .asFlowWithExtendedContextUnsafe
+        .async
+    }
+  }
+
+  test("ordered enforce ordering for static multicast partitioned flows with small batch size") {
+    val batchSize = 10
+
+    val flow = FlowWithExtendedContext[Int, Long].async
+
+    testOrder(batchSize) {
+      Partition
+        .treeBuilder[Int, Long]
+        .staticMulticast[String]({ case (_, keys) => keys }, Set("a", "b", "c", "d"))
+        .build { case _ => flow }
+    }
+  }
+
+  test("ordered enforce ordering for static multicast partitioned flows with large batch size") {
+    val batchSize = 500
+
+    val flow = FlowWithExtendedContext[Int, Long].async
+
+    testOrder(batchSize) {
+      Partition
+        .treeBuilder[Int, Long]
+        .staticMulticast[String]({ case (_, keys) => keys }, Set("a", "b", "c", "d"))
+        .build { case _ => flow }
+    }
+  }
+
+  test("ordered enforce ordering for dynamic multicast partitioned flows with small batch size") {
+    val batchSize = 10
+
+    val flow = FlowWithExtendedContext[Int, Long].async
+
+    testOrder(batchSize) {
+      Partition
+        .treeBuilder[Int, Long]
+        .dynamicManualMulticast[String]({ case (_, keys) => keys }, Set("a", "b", "c", "d"))
+        .build { case _ => flow }
+    }
+  }
+
+  test("ordered enforce ordering for dynamic multicast partitioned flows with large batch size") {
+    val batchSize = 500
+
+    val flow = FlowWithExtendedContext[Int, Long].async
+
+    testOrder(batchSize) {
+      Partition
+        .treeBuilder[Int, Long]
+        .dynamicManualMulticast[String]({ case (_, keys) => keys }, Set("a", "b", "c", "d"))
+        .build { case _ => flow }
+    }
+  }
+}


### PR DESCRIPTION
The strategy of using the context's hash code as a mechanism to match multiple elements pertaining to the same multiplexed context was subject to hash collision issues.

This caused static partitions to unpredictably fail with seemingly unrelated causes.

This MR imposes the use of global sequence numbers as the matching strategy.