### PR TITLE
PartitionTree support for unbalanced trees

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,9 @@ lazy val commonSettings = Seq(
     "-Xfatal-warnings"
   ),
   libraryDependencies := Seq(
-    scalaTest % Test
+    scalaTest % Test,
+    // Needed to make PartitionTreeBuilder type resolution work
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value
   ),
   headerLicense := Some(HeaderLicense.ALv2("2022", "Andrea Zito")),
   addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.13.2").cross(CrossVersion.full))


### PR DESCRIPTION
Partition tree now allows to define child partitions based on the parent keys.

This allows to have unbalanced trees with different subtrees.