### PR TITLE
Support for zipping FlowWithExtendedContext

### DIFF
--- a/spekka-context/src/main/scala/spekka/context/FlowWithExtendedContext.scala
+++ b/spekka-context/src/main/scala/spekka/context/FlowWithExtendedContext.scala
@@ -20,17 +20,17 @@ import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Graph
+import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.FlowWithContext
+import akka.stream.scaladsl.GraphDSL
 import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Zip
 import spekka.context.internal._
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import akka.stream.scaladsl.GraphDSL
-import akka.stream.scaladsl.Broadcast
-import akka.stream.scaladsl.Zip
 
 /** Provides the implicit conversions needed to make [[FlowWithExtendedContext]] interoperatee with
   * standard akka flows.

--- a/spekka-context/src/test/scala/spekka/context/FlowWithExtendedContextSuite.scala
+++ b/spekka-context/src/test/scala/spekka/context/FlowWithExtendedContextSuite.scala
@@ -22,6 +22,7 @@ import akka.stream.scaladsl.FlowWithContext
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import spekka.test.SpekkaSuite
+import akka.stream.scaladsl.Keep
 
 class FlowWithExtendedContextSuite
     extends SpekkaSuite(
@@ -124,6 +125,208 @@ class FlowWithExtendedContextSuite
     val sinkProbe = Source(inputs)
       .via(flow)
       .runWith(TestSink.probe)
+
+    sinkProbe
+      .request(inputs.size + 1L)
+      .expectNextN(expected)
+      .expectComplete()
+  }
+
+  test("Zip of 2 FlowWithExtendedContext") {
+    import FlowWithExtendedContext.syntax._
+    case class Out1(s: String)
+    case class Out2(s: String)
+
+    val flow1 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out1(s"${in}-1")
+      }
+      .mapMaterializedValue(_ => 1)
+
+    val flow2 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out2(s"${in}-2")
+      }
+      .mapMaterializedValue(_ => 2)
+
+    val testFlow = FlowWithExtendedContext.zip(flow1, flow2)
+
+    val inputs = List("one", "two", "three").zipWithIndex
+    val expected = inputs.map { case (s, i) =>
+      val outs = (Out1(s"$s-1"), Out2(s"$s-2"))
+      outs -> i
+    }
+
+    val expectedMats = (1, 2)
+
+    val (mats, sinkProbe) = Source(inputs)
+      .viaMat(testFlow)(Keep.right)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+    mats shouldEqual expectedMats
+
+    sinkProbe
+      .request(inputs.size + 1L)
+      .expectNextN(expected)
+      .expectComplete()
+  }
+
+  test("Zip of 3 FlowWithExtendedContext") {
+    import FlowWithExtendedContext.syntax._
+    case class Out1(s: String)
+    case class Out2(s: String)
+    case class Out3(s: String)
+
+    val flow1 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out1(s"${in}-1")
+      }
+      .mapMaterializedValue(_ => 1)
+
+    val flow2 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out2(s"${in}-2")
+      }
+      .mapMaterializedValue(_ => 2)
+
+    val flow3 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out3(s"${in}-3")
+      }
+      .mapMaterializedValue(_ => 3)
+
+    val testFlow = FlowWithExtendedContext.zip(flow1, flow2, flow3)
+
+    val inputs = List("one", "two", "three").zipWithIndex
+    val expected = inputs.map { case (s, i) =>
+      val outs = (Out1(s"$s-1"), Out2(s"$s-2"), Out3(s"$s-3"))
+      outs -> i
+    }
+
+    val expectedMats = (1, 2, 3)
+
+    val (mats, sinkProbe) = Source(inputs)
+      .viaMat(testFlow)(Keep.right)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+    mats shouldEqual expectedMats
+
+    sinkProbe
+      .request(inputs.size + 1L)
+      .expectNextN(expected)
+      .expectComplete()
+  }
+
+  test("Zip of 4 FlowWithExtendedContext") {
+    import FlowWithExtendedContext.syntax._
+    case class Out1(s: String)
+    case class Out2(s: String)
+    case class Out3(s: String)
+    case class Out4(s: String)
+
+    val flow1 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out1(s"${in}-1")
+      }
+      .mapMaterializedValue(_ => 1)
+
+    val flow2 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out2(s"${in}-2")
+      }
+      .mapMaterializedValue(_ => 2)
+
+    val flow3 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out3(s"${in}-3")
+      }
+      .mapMaterializedValue(_ => 3)
+
+    val flow4 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out4(s"${in}-4")
+      }
+      .mapMaterializedValue(_ => 4)
+
+    val testFlow = FlowWithExtendedContext.zip(flow1, flow2, flow3, flow4)
+
+    val inputs = List("one", "two", "three").zipWithIndex
+    val expected = inputs.map { case (s, i) =>
+      val outs = (Out1(s"$s-1"), Out2(s"$s-2"), Out3(s"$s-3"), Out4(s"$s-4"))
+      outs -> i
+    }
+
+    val expectedMats = (1, 2, 3, 4)
+
+    val (mats, sinkProbe) = Source(inputs)
+      .viaMat(testFlow)(Keep.right)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+    mats shouldEqual expectedMats
+
+    sinkProbe
+      .request(inputs.size + 1L)
+      .expectNextN(expected)
+      .expectComplete()
+  }
+
+  test("Zip of 5 FlowWithExtendedContext") {
+    import FlowWithExtendedContext.syntax._
+    case class Out1(s: String)
+    case class Out2(s: String)
+    case class Out3(s: String)
+    case class Out4(s: String)
+    case class Out5(s: String)
+
+    val flow1 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out1(s"${in}-1")
+      }
+      .mapMaterializedValue(_ => 1)
+
+    val flow2 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out2(s"${in}-2")
+      }
+      .mapMaterializedValue(_ => 2)
+
+    val flow3 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out3(s"${in}-3")
+      }
+      .mapMaterializedValue(_ => 3)
+
+    val flow4 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out4(s"${in}-4")
+      }
+      .mapMaterializedValue(_ => 4)
+
+    val flow5 = FlowWithExtendedContext[String, Int]
+      .map { in =>
+        Out5(s"${in}-5")
+      }
+      .mapMaterializedValue(_ => 5)
+
+    val testFlow = FlowWithExtendedContext.zip(flow1, flow2, flow3, flow4, flow5)
+
+    val inputs = List("one", "two", "three").zipWithIndex
+    val expected = inputs.map { case (s, i) =>
+      val outs = (Out1(s"$s-1"), Out2(s"$s-2"), Out3(s"$s-3"), Out4(s"$s-4"), Out5(s"$s-5"))
+      outs -> i
+    }
+
+    val expectedMats = (1, 2, 3, 4, 5)
+
+    val (mats, sinkProbe) = Source(inputs)
+      .viaMat(testFlow)(Keep.right)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+    mats shouldEqual expectedMats
 
     sinkProbe
       .request(inputs.size + 1L)

--- a/spekka-context/src/test/scala/spekka/context/FlowWithExtendedContextSuite.scala
+++ b/spekka-context/src/test/scala/spekka/context/FlowWithExtendedContextSuite.scala
@@ -19,10 +19,10 @@ package spekka.context
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.FlowWithContext
+import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import spekka.test.SpekkaSuite
-import akka.stream.scaladsl.Keep
 
 class FlowWithExtendedContextSuite
     extends SpekkaSuite(


### PR DESCRIPTION
It is a common necessity to flow some input to multiple flows in order to gather all outputs.

The partitioning support of *spekka* cover most of the common cases, however it does require that the flow participating in the partitioning have the same output.

This PR adds support for zipping multiple `FlowWithExtendedContext` sharing the same input and context by tupling the outputs and materialized values (both of which can be of different types).